### PR TITLE
feat: migrate dnsprove

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2258,16 +2258,6 @@
         "@ethersproject/strings": "^5.4.0"
       }
     },
-    "@govtechsg/dnsprove": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@govtechsg/dnsprove/-/dnsprove-2.6.1.tgz",
-      "integrity": "sha512-ALLe3EC9ix6ZsMIHgRRLdVYMC35yRShG8sRXb73D4bvw60Yz/pT/Y3e9w40KqG8HMMChvJaEMV6uQi6GR7Jwmw==",
-      "requires": {
-        "axios": "^0.21.1",
-        "debug": "^4.3.1",
-        "runtypes": "^6.3.0"
-      }
-    },
     "@govtechsg/document-store": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@govtechsg/document-store/-/document-store-2.2.3.tgz",
@@ -5361,6 +5351,16 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
+    },
+    "@tradetrust/dnsprove": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@tradetrust/dnsprove/-/dnsprove-2.7.0.tgz",
+      "integrity": "sha512-x9uld0ayO/egOPgE7HvO0V+Ug8rwctKoZsUARQN6qccowEQoOqNPxRs/hILB0UYw4vjLIBxymwoYkBD2pBdltw==",
+      "requires": {
+        "axios": "^0.21.1",
+        "debug": "^4.3.1",
+        "runtypes": "^6.3.0"
+      }
     },
     "@tradetrust/open-attestation": {
       "version": "6.8.0-alpha.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@govtechsg/dnsprove": "^2.6.1",
+    "@tradetrust/dnsprove": "^2.7.0",
     "@govtechsg/document-store": "^2.2.3",
     "@govtechsg/token-registry": "^4.1.7",
     "@tradetrust/open-attestation": "^6.8.0-alpha.2",

--- a/src/verifiers/issuerIdentity/dnsDid/dnsDidProof.ts
+++ b/src/verifiers/issuerIdentity/dnsDid/dnsDidProof.ts
@@ -1,5 +1,5 @@
 import { getData, utils, v2, v3, OAv4, TTv4 } from "@tradetrust/open-attestation";
-import { getDnsDidRecords } from "@govtechsg/dnsprove";
+import { getDnsDidRecords } from "@tradetrust/dnsprove";
 import { VerificationFragmentType, Verifier } from "../../../types/core";
 import { OpenAttestationDnsDidCode } from "../../../types/error";
 import { withCodedErrorHandler } from "../../../common/errorHandler";

--- a/src/verifiers/issuerIdentity/dnsTxt/openAttestationDnsTxt.ts
+++ b/src/verifiers/issuerIdentity/dnsTxt/openAttestationDnsTxt.ts
@@ -1,5 +1,5 @@
 import { getData, utils, v2, v3 } from "@tradetrust/open-attestation";
-import { getDocumentStoreRecords } from "@govtechsg/dnsprove";
+import { getDocumentStoreRecords } from "@tradetrust/dnsprove";
 import { VerificationFragmentType, Verifier, VerifierOptions } from "../../../types/core";
 import { OpenAttestationDnsTxtCode } from "../../../types/error";
 import { withCodedErrorHandler } from "../../../common/errorHandler";


### PR DESCRIPTION
This pr migrates to the forked tt version of dnsprove.
